### PR TITLE
Likes are a separate resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you already have it installed, run the server by: `$ json-server --watch db.j
 * Populate page with quotes with a `GET` request to `http://localhost:3000/quotes`.
 
 * Each quotes should have the following structure:
-  ```
+  ```html
     <li class='quote-card'>
       <blockquote class="blockquote">
         <p class="mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you already have it installed, run the server by: `$ json-server --watch db.j
   ```
 * Submitting the form creates a new quote and adds it to the list of quotes without having to refresh the page. (Whether you choose to optimistically render or not is up to you).
 * Clicking the delete button should delete the respective quote from the database and remove it from the page without having to refresh.
-* Clicking the like button will increase the number of likes for this particular comment in the database and on the page without having to refresh. Use a `POST` request to `http://localhost:3000/quotes/id` and include a JSON object as the body containing a key of `quoteId` with an integer value for the ID of the quote you're creating the like for — e.g. `{ quoteId: 5 }`   
+* Clicking the like button will increase the number of likes for this particular comment in the database and on the page without having to refresh. Use a `POST` request to `http://localhost:3000/quotes/id` and include a JSON object as the body containing a key of `quoteId` with an integer value for the ID of the quote you're creating the like for — e.g. `{ quoteId: 5 }` to like quote 5.   
 
 ### BONUS
 * Add an edit button to each quote-card that will allow the editing of a quote. _(Hint: there is no 'correct' way to do this. You can try creating a hidden form that will only show up when hitting the edit button.)_

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ db.json`.
 ## Extend Your Learning
 
 * Add an edit button to each quote-card that will allow the editing of a quote. _(Hint: there is no 'correct' way to do this. You can try creating a hidden form that will only show up when hitting the edit button.)_
-* Add a sort button on the page that I can toggle on and off that will sort the list of quotes by author name (instead of just listing them in order of ID)
+  * Add a sort button that can be toggled on or off. When off the list of
+    quotes will appear sorted by the ID. When the sort is active, it will
+    display the quotes by author's name, alphabetically.
   * One way of doing this is to sort the quotes in JS after you've retrieved them from the API. Try this way first.
   * Another way of doing this is to make a fetch to `http://localhost:3000/quotes?_sort=author`
   * What are the pros and cons in doing the sorting on the client vs. the server? Discuss with a partner.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you already have it installed, run the server by: `$ json-server --watch db.j
   ```
 * Submitting the form creates a new quote and adds it to the list of quotes without having to refresh the page. (Whether you choose to optimistically render or not is up to you).
 * Clicking the delete button should delete the respective quote from the database and remove it from the page without having to refresh.
-* Clicking the like button will increase the number of likes for this particular comment in the database and on the page without having to refresh. Use a `POST` request to `http://localhost:3000/quotes/id` and include a JSON object as the body containing a key of `quoteId` with an integer value for the ID of the quote you're creating the like for (e.g. `{ quoteId: 5 }`)   
+* Clicking the like button will increase the number of likes for this particular comment in the database and on the page without having to refresh. Use a `POST` request to `http://localhost:3000/quotes/id` and include a JSON object as the body containing a key of `quoteId` with an integer value for the ID of the quote you're creating the like for — e.g. `{ quoteId: 5 }`   
 
 ### BONUS
 * Add an edit button to each quote-card that will allow the editing of a quote. _(Hint: there is no 'correct' way to do this. You can try creating a hidden form that will only show up when hitting the edit button.)_

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ db.json`.
   * The body of the request should be a JSON object containing a key of
     `quoteId`, with an integer value. Use the ID of the quote you're creating
     the like for — e.g. `{ quoteId: 5 }` to create a like for quote 5.
-  * Bonus (not required): add a `createdAt` key to your object to track when the like was created. Use [UNIX time](https://en.wikipedia.org/wiki/Unix_time) (the number of seconds since January 1, 1970). The [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) for the JS `Date` class may be helpful here!
+  * Bonus (not required): add a `createdAt` key to your object to track when
+    the like was created. Use [UNIX time][] (the number of seconds since
+    January 1, 1970). The  [documentation][] for the JS `Date` class may be
+    helpful here!
 
 ## Extend Your Learning
 
@@ -64,3 +67,6 @@ db.json`.
 Building an application like this is a typical interview exercise. It's not
 uncommon to be set in front of a foreign computer (or asked to bring your own)
 and to receive a specification like this.
+
+[UNIX time]: https://en.wikipedia.org/wiki/Unix_time
+[documentation]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date

--- a/README.md
+++ b/README.md
@@ -26,4 +26,7 @@ If you already have it installed, run the server by: `$ json-server --watch db.j
 
 ### BONUS
 * Add an edit button to each quote-card that will allow the editing of a quote. _(Hint: there is no 'correct' way to do this. You can try creating a hidden form that will only show up when hitting the edit button.)_
-* Add a sort button on the page that I can toggle on and off that will sort the list of quotes by author name.
+* Add a sort button on the page that I can toggle on and off that will sort the list of quotes by author name (instead of just listing them in order of ID)
+  * One way of doing this is to sort the quotes in JS after you've retrieved them from the API. Try this way first.
+  * Another way of doing this is to make a fetch to `http://localhost:3000/quotes?_sort=author`
+  * What are the pros and cons in doing the sorting on the client vs. the server? Discuss with a partner.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ If you don't have json-server installed, run `$ npm i -g json-server`.
 If you already have it installed, run the server by: `$ json-server --watch db.json`.
 
 ### Deliverables
-* Populate page with quotes with a `GET` request to `http://localhost:3000/quotes?_embed=likes`.
+* Populate page with quotes with a `GET` request to `http://localhost:3000/quotes`.
 
-* Each quote should have the following structure:
+* Each quotes should have the following structure:
   ```
     <li class='quote-card'>
       <blockquote class="blockquote">
@@ -20,8 +20,7 @@ If you already have it installed, run the server by: `$ json-server --watch db.j
   ```
 * Submitting the form creates a new quote and adds it to the list of quotes without having to refresh the page. (Whether you choose to optimistically render or not is up to you).
 * Clicking the delete button should delete the respective quote from the database and remove it from the page without having to refresh.
-* Clicking the like button will increase the number of likes for this particular comment in the database and on the page without having to refresh.
-
+* Clicking the like button will increase the number of likes for this particular comment in the database and on the page without having to refresh. Use a `POST` request to `http://localhost:3000/quotes/id` and include a JSON object as the body containing a key of `quoteId` with an integer value for the ID of the quote you're creating the like for (e.g. `{ quoteId: 5 }`)   
 
 ### BONUS
 * Add an edit button to each quote-card that will allow the editing of a quote. _(Hint: there is no 'correct' way to do this. You can try creating a hidden form that will only show up when hitting the edit button.)_

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ db.json`.
 
 ## Build a simple, Event-driven, JavaScript DOM-modifying application
 
-* Populate page with quotes with a `GET` request to `http://localhost:3000/quotes`.
+* Populate page with quotes with a `GET` request to
+  `http://localhost:3000/quotes`.
 
 * Each quotes should have the following structure:
   ```html
@@ -33,11 +34,21 @@ db.json`.
       </blockquote>
     </li>
   ```
-* Submitting the form creates a new quote and adds it to the list of quotes without having to refresh the page. (Whether you choose to optimistically render or not is up to you).
-* Clicking the delete button should delete the respective quote from the database and remove it from the page without having to refresh.
-* Clicking the like button will create a like for this particular quote in the API and update the number of likes displayed on the page without having to refresh.
+
+* Submitting the form creates a new quote and adds it to the list of quotes
+  without having to refresh the page. (Whether you choose to optimistically
+  render or not is up to you).
+
+* Clicking the delete button should delete the respective quote from the
+  database and remove it from the page without having to refresh.
+
+* Clicking the like button will create a like for this particular quote in the
+  API and update the number of likes displayed on the page without having to
+  refresh.
   * Use a `POST` request to `http://localhost:3000/quotes/id`
-  * The body of the request should be a JSON object containing a key of `quoteId`, with an integer value. Use the ID of the quote you're creating the like for — e.g. `{ quoteId: 5 }` to create a like for quote 5.
+  * The body of the request should be a JSON object containing a key of
+    `quoteId`, with an integer value. Use the ID of the quote you're creating
+    the like for — e.g. `{ quoteId: 5 }` to create a like for quote 5.
   * Bonus (not required): add a `createdAt` key to your object to track when the like was created. Use [UNIX time](https://en.wikipedia.org/wiki/Unix_time) (the number of seconds since January 1, 1970). The [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) for the JS `Date` class may be helpful here!
 
 ## BONUS

--- a/README.md
+++ b/README.md
@@ -1,9 +1,24 @@
-## Hello, let's build a simple app that allows us to keep track of our favorite quotes and who said it.  
+# JavaScript Quotes Practice
+
+## Learning Goals
+
+1. Use `json-server` to provide a basic RESTful data store
+2. Build a simple, event-driven, JavaScript DOM-modifying application
+
+## Introduction
+
+Hello, let's build a simple app that allows us to keep track of our favorite
+quotes and who said it.  
+
+## Use `json-server` to Provide a Basic RESTful Data Store
 
 If you don't have json-server installed, run `$ npm i -g json-server`.  
-If you already have it installed, run the server by: `$ json-server --watch db.json`.
 
-### Deliverables
+If you already have it installed, run the server by: `$ json-server --watch
+db.json`.
+
+## Build a simple, Event-driven, JavaScript DOM-modifying application
+
 * Populate page with quotes with a `GET` request to `http://localhost:3000/quotes`.
 
 * Each quotes should have the following structure:
@@ -25,9 +40,16 @@ If you already have it installed, run the server by: `$ json-server --watch db.j
   * The body of the request should be a JSON object containing a key of `quoteId`, with an integer value. Use the ID of the quote you're creating the like for — e.g. `{ quoteId: 5 }` to create a like for quote 5.
   * Bonus (not required): add a `createdAt` key to your object to track when the like was created. Use [UNIX time](https://en.wikipedia.org/wiki/Unix_time) (the number of seconds since January 1, 1970). The [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) for the JS `Date` class may be helpful here!
 
-### BONUS
+## BONUS
+
 * Add an edit button to each quote-card that will allow the editing of a quote. _(Hint: there is no 'correct' way to do this. You can try creating a hidden form that will only show up when hitting the edit button.)_
 * Add a sort button on the page that I can toggle on and off that will sort the list of quotes by author name (instead of just listing them in order of ID)
   * One way of doing this is to sort the quotes in JS after you've retrieved them from the API. Try this way first.
   * Another way of doing this is to make a fetch to `http://localhost:3000/quotes?_sort=author`
   * What are the pros and cons in doing the sorting on the client vs. the server? Discuss with a partner.
+
+## Conclusion
+
+Building an application like this is a typical interview exercise. It's not
+uncommon to be set in front of a foreign computer (or asked to bring your own)
+and to receive a specification like this.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ If you already have it installed, run the server by: `$ json-server --watch db.j
   ```
 * Submitting the form creates a new quote and adds it to the list of quotes without having to refresh the page. (Whether you choose to optimistically render or not is up to you).
 * Clicking the delete button should delete the respective quote from the database and remove it from the page without having to refresh.
-* Clicking the like button will increase the number of likes for this particular comment in the database and on the page without having to refresh. Use a `POST` request to `http://localhost:3000/quotes/id` and include a JSON object as the body containing a key of `quoteId` with an integer value for the ID of the quote you're creating the like for — e.g. `{ quoteId: 5 }` to like quote 5.   
+* Clicking the like button will create a like for this particular quote in the API and update the number of likes displayed on the page without having to refresh. 
+  * Use a `POST` request to `http://localhost:3000/quotes/id`
+  * The body of the request should be a JSON object containing a key of `quoteId`, with an integer value. Use the ID of the quote you're creating the like for — e.g. `{ quoteId: 5 }` to create a like for quote 5.   
 
 ### BONUS
 * Add an edit button to each quote-card that will allow the editing of a quote. _(Hint: there is no 'correct' way to do this. You can try creating a hidden form that will only show up when hitting the edit button.)_

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ If you don't have json-server installed, run `$ npm i -g json-server`.
 If you already have it installed, run the server by: `$ json-server --watch db.json`.
 
 ### Deliverables
-* Populate page with quotes with a `GET` request to `http://localhost:3000/quotes`.
+* Populate page with quotes with a `GET` request to `http://localhost:3000/quotes?_embed=likes`.
 
-* Each quotes should have the following structure:
+* Each quote should have the following structure:
   ```
     <li class='quote-card'>
       <blockquote class="blockquote">

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ db.json`.
     the like for — e.g. `{ quoteId: 5 }` to create a like for quote 5.
   * Bonus (not required): add a `createdAt` key to your object to track when the like was created. Use [UNIX time](https://en.wikipedia.org/wiki/Unix_time) (the number of seconds since January 1, 1970). The [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) for the JS `Date` class may be helpful here!
 
-## BONUS
+## Extend Your Learning
 
 * Add an edit button to each quote-card that will allow the editing of a quote. _(Hint: there is no 'correct' way to do this. You can try creating a hidden form that will only show up when hitting the edit button.)_
 * Add a sort button on the page that I can toggle on and off that will sort the list of quotes by author name (instead of just listing them in order of ID)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ quotes and who said it.
 
 ## Use `json-server` to Provide a Basic RESTful Data Store
 
-If you don't have json-server installed, run `$ npm i -g json-server`.
+If you don't have `json-server` installed, run `$ npm i -g json-server`.
 
 If you already have it installed, run the server by: `$ json-server --watch
 db.json`.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 ## Introduction
 
 Hello, let's build a simple app that allows us to keep track of our favorite
-quotes and who said it.  
+quotes and who said it.
 
 ## Use `json-server` to Provide a Basic RESTful Data Store
 
-If you don't have json-server installed, run `$ npm i -g json-server`.  
+If you don't have json-server installed, run `$ npm i -g json-server`.
 
 If you already have it installed, run the server by: `$ json-server --watch
 db.json`.
@@ -35,7 +35,7 @@ db.json`.
   ```
 * Submitting the form creates a new quote and adds it to the list of quotes without having to refresh the page. (Whether you choose to optimistically render or not is up to you).
 * Clicking the delete button should delete the respective quote from the database and remove it from the page without having to refresh.
-* Clicking the like button will create a like for this particular quote in the API and update the number of likes displayed on the page without having to refresh. 
+* Clicking the like button will create a like for this particular quote in the API and update the number of likes displayed on the page without having to refresh.
   * Use a `POST` request to `http://localhost:3000/quotes/id`
   * The body of the request should be a JSON object containing a key of `quoteId`, with an integer value. Use the ID of the quote you're creating the like for — e.g. `{ quoteId: 5 }` to create a like for quote 5.
   * Bonus (not required): add a `createdAt` key to your object to track when the like was created. Use [UNIX time](https://en.wikipedia.org/wiki/Unix_time) (the number of seconds since January 1, 1970). The [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) for the JS `Date` class may be helpful here!

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ If you already have it installed, run the server by: `$ json-server --watch db.j
 * Clicking the delete button should delete the respective quote from the database and remove it from the page without having to refresh.
 * Clicking the like button will create a like for this particular quote in the API and update the number of likes displayed on the page without having to refresh. 
   * Use a `POST` request to `http://localhost:3000/quotes/id`
-  * The body of the request should be a JSON object containing a key of `quoteId`, with an integer value. Use the ID of the quote you're creating the like for — e.g. `{ quoteId: 5 }` to create a like for quote 5.   
+  * The body of the request should be a JSON object containing a key of `quoteId`, with an integer value. Use the ID of the quote you're creating the like for — e.g. `{ quoteId: 5 }` to create a like for quote 5.
+  * Bonus (not required): add a `createdAt` key to your object to track when the like was created. Use [UNIX time](https://en.wikipedia.org/wiki/Unix_time) (the number of seconds since January 1, 1970). The [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) for the JS `Date` class may be helpful here!
 
 ### BONUS
 * Add an edit button to each quote-card that will allow the editing of a quote. _(Hint: there is no 'correct' way to do this. You can try creating a hidden form that will only show up when hitting the edit button.)_

--- a/db.json
+++ b/db.json
@@ -3,62 +3,58 @@
     {
         "id": 1,
         "quote": "The here and now is all we have, and if we play it right it's all we'll need.",
-        "likes": 1,
         "author": "Ann Richards"
     },
     {
         "id": 2,
         "quote": "There are no secrets to success. It is the result of preparation, hard work, and learning from failure.",
-        "likes": 1,
         "author": "Collin Powell"
     },
     {
         "id": 3,
         "quote": "Don't count the days, make the days count.",
-        "likes": 1,
         "author": "Mike Tyson"
     },
     {
         "id": 4,
         "quote": "You gain strength, courage and confidence by every experience in which you really stop to look fear in the face. You are able to say to yourself, 'I have lived through this horror. I can take the next thing that comes along.' You must do the thing you think you cannot do.",
-        "likes": 1,
         "author": "Eleanor Roosevelt"
     },
     {
         "id": 5,
         "quote": "The cure for boredom is curiosity. There is no cure for curiosity.",
-        "likes": 1,
         "author": "Dorothy Parker"
     },
     {
         "id": 6,
         "quote": "Do the best you can in every task, no matter how unimportant it may seem at the time. No one learns more about a problem than the person at the bottom.",
-        "likes": 1,
         "author": "Sandra Day O'Connor"
     },
     {
         "id": 7,
         "quote": "Tell me and I forget, teach me and I remember, involve me and I learn.",
-        "likes": 1,
         "author": "Benjamin Franklin"
     },
     {
         "id": 8,
         "quote": "Success is not final, failure is not fatal: it is the courage to continue that counts.",
-        "likes": 1,
         "author": "Winston Churchhill"
     },
     {
         "id": 9,
         "quote": "Our greatest glory is not in never falling, but in rising everytime we fall.",
-        "likes": 1,
         "author": "Confucius"
     },
     {
         "id": 10,
         "quote": "You know, failure hurts. Any kind of failure stings. If you live in the sting, you will undoubtedly fail. My way of getting past the sting is to say no, I’m just not going to let this get me down.",
-        "likes": 1,
         "author": "Sonia Sotomayor"
+    }
+  ],
+  "likes": [
+    {
+        "quoteId": 1,
+        "createdAt": 1558524356
     }
   ]
 }


### PR DESCRIPTION
This PR changes likes to be a separate resource rather than an attribute of a quote.

The intent of this change is to reduce pattern-matching: many practice labs use a PATCH for likes, but the code challenge uses a POST, and many students ignore the API specs in the readme, assuming that it will just always be a PATCH. @alexgriff also points out this out doesn't match how liking would work in the real world.

As a side effect, students will have to call `.length` on the array of likes to display the number of likes in the UI. I don't think this is a bad thing.

##Bonus
- This PR also adds more details on the sort bonus feature, including a server-side sort and a compare-contrast discussion portion
- A second bonus asks students to add a timestamp to likes — we don't use this data, but I added in the interest of helping students understand `why` likes might want to be their own resource.